### PR TITLE
refactor: Adds request types as Classes

### DIFF
--- a/src/functionParser.ts
+++ b/src/functionParser.ts
@@ -156,10 +156,11 @@ export class FunctionParser {
     router: express.Router
   ) {
     const filePath = parse(file);
-    /** @type {*} */
-    const name = filePath.name.replace('.endpoint', '');
+
     /** @type {*} */
     var endpoint = require(file).default as Endpoint;
+    /** @type {*} */
+    const name = endpoint.name || filePath.name.replace('.endpoint', '');
     /** @type {*} */
     var handler = endpoint.handler;
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -14,23 +14,40 @@ export interface IExpressHandler {
  * Stores the information to be used when creating a restful endpoint on the backend
  */
 export class Endpoint {
-  name: string;
-  handler: Function;
+  handler: IExpressHandler;
   requestType: RequestType;
 
-  constructor(
-    name: string,
-    requestType: RequestType,
-    handler: IExpressHandler
-  ) {
-    if (!name || name.length < 1) {
-      throw 'Please provide the endpoint name. Endpoint name cannot be blank.';
-    }
+  constructor(requestType: RequestType, handler: IExpressHandler) {
     if (!handler) {
       throw 'Please provide a endpoint request handler.';
     }
-    this.name = name;
     this.handler = handler;
     this.requestType = requestType;
+  }
+}
+
+export class Get extends Endpoint {
+  constructor(handler: IExpressHandler) {
+    super(RequestType.GET, handler);
+  }
+}
+export class Post extends Endpoint {
+  constructor(handler: IExpressHandler) {
+    super(RequestType.POST, handler);
+  }
+}
+export class Put extends Endpoint {
+  constructor(handler: IExpressHandler) {
+    super(RequestType.PUT, handler);
+  }
+}
+export class Delete extends Endpoint {
+  constructor(handler: IExpressHandler) {
+    super(RequestType.DELETE, handler);
+  }
+}
+export class Patch extends Endpoint {
+  constructor(handler: IExpressHandler) {
+    super(RequestType.PATCH, handler);
   }
 }

--- a/src/models.ts
+++ b/src/models.ts
@@ -14,40 +14,42 @@ export interface IExpressHandler {
  * Stores the information to be used when creating a restful endpoint on the backend
  */
 export class Endpoint {
-  handler: IExpressHandler;
-  requestType: RequestType;
-
-  constructor(requestType: RequestType, handler: IExpressHandler) {
+  constructor(
+    /**
+     * @deprecated "name" parameter is no longer needed
+     */
+    public name: string | undefined,
+    public requestType: RequestType,
+    public handler: IExpressHandler
+  ) {
     if (!handler) {
       throw 'Please provide a endpoint request handler.';
     }
-    this.handler = handler;
-    this.requestType = requestType;
   }
 }
 
 export class Get extends Endpoint {
   constructor(handler: IExpressHandler) {
-    super(RequestType.GET, handler);
+    super(undefined, RequestType.GET, handler);
   }
 }
 export class Post extends Endpoint {
   constructor(handler: IExpressHandler) {
-    super(RequestType.POST, handler);
+    super(undefined, RequestType.POST, handler);
   }
 }
 export class Put extends Endpoint {
   constructor(handler: IExpressHandler) {
-    super(RequestType.PUT, handler);
+    super(undefined, RequestType.PUT, handler);
   }
 }
 export class Delete extends Endpoint {
   constructor(handler: IExpressHandler) {
-    super(RequestType.DELETE, handler);
+    super(undefined, RequestType.DELETE, handler);
   }
 }
 export class Patch extends Endpoint {
   constructor(handler: IExpressHandler) {
-    super(RequestType.PATCH, handler);
+    super(undefined, RequestType.PATCH, handler);
   }
 }


### PR DESCRIPTION
I made a few changes to hopefully eliminate some boilerplate / potential spots for errors in authoring:
```js
import { Request, Response } from "express";
import { Post } from "firebase-backend";

export default new Post((req: Request, res: Response) => {...});
```

Now when authoring a restful endpoint:
1. You can just use `Post`, `Get`, etc... instead of `Endpoint([name],RequestType[TYPE],...)`
2. You don't need to specify the name - that comes from the filename itself


I also did a little cleanup in the logs and function structure.